### PR TITLE
fix: 修复 Windows 打包问题 - DLL 加载路径和 speakers 文件

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
           
           # Copy Readme
           cp README.md dist/
+          
+          # Copy Speakers
+          cp -r speakers/* dist/speakers/
 
       - name: Download and Bundle Runtimes (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## 问题描述

Fixes #1

### 问题1: Windows 上找不到 onnxruntime.dll
- Windows 默认从 exe 所在目录加载 DLL
- 程序尝试加载 \onnxruntime.dll\ 但找不到 \untime/\ 目录下的文件

### 问题2: speakers 目录为空
- 打包脚本创建了空的 \dist/speakers\ 目录但没有复制实际的 speaker JSON 文件
- 导致运行时报错 \No speakers loaded in engine!\

## 修复内容

### 1. 改进 ONNX Runtime 加载逻辑 (\src/models/onnx_runtime.rs\)
- 在加载 DLL 前设置 DLL 搜索路径（Windows 使用 \SetDllDirectoryW\ 和 PATH 环境变量）
- 尝试多个路径加载库：当前目录、\untime/\、\./runtime/\
- Unix 系统同样设置 \LD_LIBRARY_PATH\ 或 \DYLD_LIBRARY_PATH\

### 2. 修复打包脚本 (\.github/workflows/release.yml\)
- 复制 \speakers/*\ 到 \dist/speakers/\

## 测试
- 编译通过 (\cargo build --release\)
- Clippy 检查通过