### PR TITLE
fix: improve library extraction and bake RPATH into binary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,1 +1,24 @@
-fn main() {}
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if target_os == "linux" {
+        // Set the RPATH for the binary
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/runtime");
+
+        // Optional: Automatically link the runtime folder into the target directory
+        // so 'cargo run' works without extra RPATHs
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let profile_dir = out_dir.join("../../../"); // Points to target/debug or target/release
+        let project_runtime =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("runtime");
+        let target_runtime = profile_dir.join("runtime");
+
+        if project_runtime.exists() && !target_runtime.exists() {
+            #[cfg(unix)]
+            let _ = std::os::unix::fs::symlink(project_runtime, target_runtime);
+        }
+    }
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -330,13 +330,37 @@ impl Downloader {
             }
 
             // Simplified check for libraries
-            if path_str.ends_with(".so")
+            if path_str.contains(".so") // Linux catches .so, .so.1, .so.1.2.3
                 || path_str.ends_with(".dylib")
                 || path_str.ends_with(".dll")
             {
                 let file_name = path.file_name().unwrap();
                 let dest_file = dest.join(file_name);
-                entry.unpack(dest_file)?;
+
+                let header = entry.header();
+
+                match header.entry_type() {
+                    tar::EntryType::Symlink => {
+                        if let Ok(Some(target_path)) = entry.link_name() {
+                            #[cfg(unix)]
+                            {
+                                // Remove existing file/link to avoid "File exists" error
+                                let _ = std::fs::remove_file(&dest_file);
+
+                                // target_path is a Cow<Path>, we use as_ref() to get the &Path
+                                std::os::unix::fs::symlink(target_path.as_ref(), &dest_file)?;
+                            }
+                            #[cfg(not(unix))]
+                            {
+                                entry.unpack(dest_file)?;
+                            }
+                        }
+                    }
+                    tar::EntryType::Regular | tar::EntryType::Continuous => {
+                        entry.unpack(dest_file)?;
+                    }
+                    _ => continue,
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Fixed extraction logic to handle Linux .so symlinks correctly. Added $ORIGIN rpath to build.rs so the binary finds libraries in the runtime folder automatically without LD_LIBRARY_PATH.

#7 